### PR TITLE
Added new functionality to find byte-offset after function prologue.

### DIFF
--- a/tests/integration/test_trace.py
+++ b/tests/integration/test_trace.py
@@ -15,19 +15,23 @@ from tracerface.web_ui.ui_format import (
 
 
 EXPECTED_NODES = [
-    {'name': '__libc_start_main', 'count': 0, 'source': 'libc-2.27.so'},
+    {'name': '__libc_start_main', 'count': 0, 'source': 'libc-2.31.so'},
     {'name': 'func1', 'count': 2, 'source': 'test_application'},
     {'name': 'func2', 'count': 1, 'source': 'test_application'},
     {'name': 'func3', 'count': 5, 'source': 'test_application'},
+    {'name': 'func4', 'count': 0, 'source': 'test_application'},
+    {'name': 'func5', 'count': 0, 'source': 'test_application'},
     {'name': 'func6', 'count': 0, 'source': 'test_application'},
     {'name': 'main', 'count': 0, 'source': 'test_application'}
 ]
 
 
 EXPECTED_EDGES = [
-    {'call_count': 2, 'called_name': 'func1', 'caller_name': 'func6', 'params': '...'},
-    {'call_count': 1, 'called_name': 'func2', 'caller_name': 'func6', 'params': '3'},
-    {'call_count': 5, 'called_name': 'func3', 'caller_name': 'func6', 'params': ''},
+    {'call_count': 2, 'called_name': 'func1', 'caller_name': 'func5', 'params': '...'},
+    {'call_count': 1, 'called_name': 'func2', 'caller_name': 'func4', 'params': '3'},
+    {'call_count': 5, 'called_name': 'func3', 'caller_name': 'func4', 'params': ''},
+    {'call_count': 0, 'called_name': 'func4', 'caller_name': 'func6', 'params': ''},
+    {'call_count': 0, 'called_name': 'func5', 'caller_name': 'func6', 'params': ''},
     {'call_count': 0, 'called_name': 'func6', 'caller_name': 'main', 'params': ''},
     {'call_count': 0, 'called_name': 'main', 'caller_name': '__libc_start_main', 'params': ''}
 ]

--- a/tests/resources/test_static_output
+++ b/tests/resources/test_static_output
@@ -1,64 +1,64 @@
-PID    TID    COMM         FUNC             -
-24622  24622  test_applicatio func2            3
--14
-b'func2+0x0 [test_application]''
-b'func6+0xe [test_application]''
-b'main+0x19 [test_application]'
-b'__libc_start_main+0xe7 [libc-2.27.so]'
-b'[unknown]'
+PID     TID     COMM            FUNC             -
+78862   78862   test_applicatio func2            3
+        -14
+        func2+0x8 [test_application]
+        func4+0x12 [test_application]
+        func6+0x12 [test_application]
+        main+0x1d [test_application]
+        __libc_start_main+0xf3 [libc-2.31.so]
 
-24622  24622  test_applicatio func3
--14
-b'func3+0x0 [test_application]''
-b'func6+0xe [test_application]''
-b'main+0x19 [test_application]'
-b'__libc_start_main+0xe7 [libc-2.27.so]'
-b'[unknown]'
+78862   78862   test_applicatio func3            
+        -14
+        func3+0x8 [test_application]
+        func4+0x1c [test_application]
+        func6+0x12 [test_application]
+        main+0x1d [test_application]
+        __libc_start_main+0xf3 [libc-2.31.so]
 
-24622  24622  test_applicatio func3
--14
-b'func3+0x0 [test_application]'
-b'func6+0xe [test_application]'
-b'main+0x19 [test_application]'
-b'__libc_start_main+0xe7 [libc-2.27.so]'
-b'[unknown]'
+78862   78862   test_applicatio func3            
+        -14
+        func3+0x8 [test_application]
+        func4+0x26 [test_application]
+        func6+0x12 [test_application]
+        main+0x1d [test_application]
+        __libc_start_main+0xf3 [libc-2.31.so]
 
-24622  24622  test_applicatio func3
--14
-b'func3+0x0 [test_application]'
-b'func6+0xe [test_application]'
-b'main+0x19 [test_application]'
-b'__libc_start_main+0xe7 [libc-2.27.so]'
-b'[unknown]'
+78862   78862   test_applicatio func3            
+        -14
+        func3+0x8 [test_application]
+        func4+0x30 [test_application]
+        func6+0x12 [test_application]
+        main+0x1d [test_application]
+        __libc_start_main+0xf3 [libc-2.31.so]
 
-24622  24622  test_applicatio func3
--14
-b'func3+0x0 [test_application]'
-b'func6+0xe [test_application]'
-b'main+0x19 [test_application]'
-b'__libc_start_main+0xe7 [libc-2.27.so]'
-b'[unknown]'
+78862   78862   test_applicatio func3            
+        -14
+        func3+0x8 [test_application]
+        func4+0x3a [test_application]
+        func6+0x12 [test_application]
+        main+0x1d [test_application]
+        __libc_start_main+0xf3 [libc-2.31.so]
 
-24622  24622  test_applicatio func3
--14
-b'func3+0x0 [test_application]'
-b'func6+0xe [test_application]'
-b'main+0x19 [test_application]'
-b'__libc_start_main+0xe7 [libc-2.27.so]'
-b'[unknown]'
+78862   78862   test_applicatio func3            
+        -14
+        func3+0x8 [test_application]
+        func4+0x44 [test_application]
+        func6+0x12 [test_application]
+        main+0x1d [test_application]
+        __libc_start_main+0xf3 [libc-2.31.so]
 
-24622  24622  test_applicatio func1            param1 param2
--14
-b'func1+0x0 [test_application]'
-b'func6+0x18 [test_application]'
-b'main+0x19 [test_application]'
-b'__libc_start_main+0xe7 [libc-2.27.so]'
-b'[unknown]'
+78862   78862   test_applicatio func1            param1 param2
+        -14
+        func1+0x8 [test_application]
+        func5+0x2c [test_application]
+        func6+0x1c [test_application]
+        main+0x1d [test_application]
+        __libc_start_main+0xf3 [libc-2.31.so]
 
-24622  24622  test_applicatio func1            param3 param4
--14
-b'func1+0x0 [test_application]'
-b'func6+0x18 [test_application]'
-b'main+0x19 [test_application]'
-b'__libc_start_main+0xe7 [libc-2.27.so]'
-b'[unknown]'
+78862   78862   test_applicatio func1            param3 param4
+        -14
+        func1+0x8 [test_application]
+        func5+0x3f [test_application]
+        func6+0x1c [test_application]
+        main+0x1d [test_application]
+        __libc_start_main+0xf3 [libc-2.31.so]

--- a/tests/unit/web_ui/test_trace_setup.py
+++ b/tests/unit/web_ui/test_trace_setup.py
@@ -9,6 +9,7 @@ from tracerface.web_ui.trace_setup import (
     BinaryNotExistsError,
     ConfigFileError,
     FunctionNotInBinaryError,
+    BuiltInNotExistsError,
     Setup
 )
 
@@ -16,11 +17,11 @@ from tracerface.web_ui.trace_setup import (
 def dummy_setup():
     return {
         'app1': {
-            'func1': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc1'},
-            'func3': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc3'},
+            'func1': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc1', 'offset': 0},
+            'func3': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc3', 'offset': 0}
         },
         'app2': {
-            'func2': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc2'},
+            'func2': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc2', 'offset': 0}
         }
     }
 
@@ -34,9 +35,9 @@ class TestInitBinary(TestCase):
 
         expected = {
             'app': {
-                'func1': {'mangled': 'func1', 'traced': False, 'parameters': {}},
-                'func2': {'mangled': 'func2', 'traced': False, 'parameters': {}},
-                'func3': {'mangled': 'func3', 'traced': False, 'parameters': {}}
+                'func1': {'mangled': 'func1', 'traced': False, 'parameters': {}, 'offset': 0},
+                'func2': {'mangled': 'func2', 'traced': False, 'parameters': {}, 'offset': 0},
+                'func3': {'mangled': 'func3', 'traced': False, 'parameters': {}, 'offset': 0}
             }
         }
         self.assertEqual(setup._setup, expected)
@@ -62,20 +63,21 @@ class TestRemoveApp(TestCase):
 
         expected = {
             'app1': {
-                'func1': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc1'},
-                'func3': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc3'}
+                'func1': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc1', 'offset': 0},
+                'func3': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc3', 'offset': 0}
             }
         }
         self.assertEqual(setup._setup, expected)
 
 
 class TestInitBuiltin(TestCase):
-    def test_initialize_built_in(self):
+    @patch('tracerface.web_ui.trace_setup.Setup.get_offset_for_built_in', return_value=12)
+    def test_initialize_built_in(self, get_offset_for_built_in):
         setup = Setup()
 
         setup.initialize_built_in('app')
 
-        expected = {'built-ins': {'app': {'traced': True, 'parameters': {}}}}
+        expected = {'built-ins': {'app': {'traced': True, 'parameters': {}, 'offset': 12}}}
         self.assertEqual(setup._setup, expected)
 
 
@@ -97,14 +99,15 @@ class TestGetAppSetup(TestCase):
         result = setup.get_setup_of_app('app1')
 
         expected = {
-            'func1': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc1'},
-            'func3': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc3'}
+            'func1': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc1', 'offset': 0},
+            'func3': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc3', 'offset': 0}
         }
         self.assertEqual(result, expected)
 
 
 class TestSetupFunctionToTrace(TestCase):
-    def test_setup_function_to_trace_with_demangled_name(self):
+    @patch('tracerface.web_ui.trace_setup.Setup.get_offset_for_function', return_value=8)
+    def test_setup_function_to_trace_with_demangled_name(self, get_offset_for_function):
         setup = Setup()
         setup._setup = dummy_setup()
 
@@ -112,16 +115,17 @@ class TestSetupFunctionToTrace(TestCase):
 
         expected = {
             'app1': {
-                'func1': {'traced': True, 'parameters': {}, 'mangled': 'mangledfunc1'},
-                'func3': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc3'}
+                'func1': {'traced': True, 'parameters': {}, 'mangled': 'mangledfunc1', 'offset': 8},
+                'func3': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc3', 'offset': 0}
             },
             'app2': {
-                'func2': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc2'},
+                'func2': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc2', 'offset': 0}
             }
         }
         self.assertEqual(setup._setup, expected)
 
-    def test_setup_function_to_trace_with_mangled_name(self):
+    @patch('tracerface.web_ui.trace_setup.Setup.get_offset_for_function', return_value=10)
+    def test_setup_function_to_trace_with_mangled_name(self, get_offset_for_function):
         setup = Setup()
         setup._setup = dummy_setup()
 
@@ -129,11 +133,11 @@ class TestSetupFunctionToTrace(TestCase):
 
         expected = {
             'app1': {
-                'func1': {'traced': True, 'parameters': {}, 'mangled': 'mangledfunc1'},
-                'func3': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc3'}
+                'func1': {'traced': True, 'parameters': {}, 'mangled': 'mangledfunc1', 'offset': 10},
+                'func3': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc3', 'offset': 0}
             },
             'app2': {
-                'func2': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc2'},
+                'func2': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc2', 'offset': 0}
             }
         }
         self.assertEqual(setup._setup, expected)
@@ -146,23 +150,31 @@ class TestSetupFunctionToTrace(TestCase):
 
 
 class TestRemoveFunctionFromTrace(TestCase):
-    def test_remove_function_from_trace_with_demangled_name(self):
+    @patch('tracerface.web_ui.trace_setup.Setup.get_offset_for_function', return_value=8)
+    def test_remove_function_from_trace_with_demangled_name(self, get_offset_for_function):
         setup = Setup()
         setup._setup = dummy_setup()
 
         setup.setup_function_to_trace('app1', 'func1')
         setup.remove_function_from_trace('app1', 'func1')
 
-        self.assertEqual(setup._setup, dummy_setup())
+        expected_setup = dummy_setup()
+        expected_setup['app1']['func1']['offset'] = 8
 
-    def test_remove_function_from_trace_with_mangled_name(self):
+        self.assertEqual(setup._setup, expected_setup)
+
+    @patch('tracerface.web_ui.trace_setup.Setup.get_offset_for_function', return_value=8)
+    def test_remove_function_from_trace_with_mangled_name(self, get_offset_for_function):
         setup = Setup()
         setup._setup = dummy_setup()
 
         setup.setup_function_to_trace('app1', 'func1')
         setup.remove_function_from_trace('app1', 'mangledfunc1')
 
-        self.assertEqual(setup._setup, dummy_setup())
+        expected_setup = dummy_setup()
+        expected_setup['app1']['func1']['offset'] = 8
+
+        self.assertEqual(setup._setup, expected_setup)
 
     def test_remove_function_from_trace_raises_error_if_function_not_exists(self):
         setup = Setup()
@@ -174,7 +186,7 @@ class TestRemoveFunctionFromTrace(TestCase):
 class TestParameters(TestCase):
     def test_get_parameters(self):
         setup = Setup()
-        setup._setup = {'app': {'func': {'traced': False, 'parameters': {1: '%s', 4: '%d'}}}}
+        setup._setup = {'app': {'func': {'traced': False, 'parameters': {1: '%s', 4: '%d'}, 'offset': 0}}}
 
         result = setup.get_parameters('app', 'func')
 
@@ -188,22 +200,22 @@ class TestParameters(TestCase):
 
         expected = {
             'app1': {
-                'func1': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc1'},
-                'func3': {'traced': False, 'parameters': {2: '%s'}, 'mangled': 'mangledfunc3'}
+                'func1': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc1', 'offset': 0},
+                'func3': {'traced': False, 'parameters': {2: '%s'}, 'mangled': 'mangledfunc3', 'offset': 0}
             },
             'app2': {
-                'func2': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc2'},
+                'func2': {'traced': False, 'parameters': {}, 'mangled': 'mangledfunc2', 'offset': 0}
             }
         }
         self.assertEqual(setup._setup, expected)
 
     def test_remove_parameter(self):
         setup = Setup()
-        setup._setup = {'app': {'func': {'traced': False, 'parameters': {1: '%s', 4: '%d'}}}}
+        setup._setup = {'app': {'func': {'traced': False, 'parameters': {1: '%s', 4: '%d'}, 'offset': 0}}}
 
         setup.remove_parameter('app', 'func', 4)
 
-        expected = {'app': {'func': {'traced': False, 'parameters': {1: '%s'}}}}
+        expected = {'app': {'func': {'traced': False, 'parameters': {1: '%s'}, 'offset': 0}}}
         self.assertEqual(setup._setup, expected)
 
 class TestGenerateBCCArgs(TestCase):
@@ -211,19 +223,19 @@ class TestGenerateBCCArgs(TestCase):
         setup = Setup()
         setup._setup = {
             'app1': {
-                'func1': {'mangled': 'mangled1', 'traced': True, 'parameters':{4: '%s', 2: '%d'}},
-                'func2': {'mangled': 'mangled2', 'traced': False, 'parameters':{}}
+                'func1': {'mangled': 'mangled1', 'traced': True, 'parameters':{4: '%s', 2: '%d'}, 'offset': 8},
+                'func2': {'mangled': 'mangled2', 'traced': False, 'parameters':{}, 'offset': 0}
             },
             'app2': {
-                'func3': {'mangled': 'mangled3', 'traced': True, 'parameters':{1: '%s', 5: '%d'}},
-                'func4': {'mangled': 'mangled4', 'traced': True, 'parameters':{1: '%s', 2: '%f'}}
+                'func3': {'mangled': 'mangled3', 'traced': True, 'parameters':{1: '%s', 5: '%d'}, 'offset': 11},
+                'func4': {'mangled': 'mangled4', 'traced': True, 'parameters':{1: '%s', 2: '%f'}, 'offset': 16}
             }
         }
         result = setup.generate_bcc_args()
         expected = [
-            'app1:mangled1 "%s %d", arg4, arg2',
-            'app2:mangled3 "%s %d", arg1, arg5',
-            'app2:mangled4 "%s %f", arg1, arg2',
+            'app1:mangled1+0x8 "%s %d", arg4, arg2',
+            'app2:mangled3+0xB "%s %d", arg1, arg5',
+            'app2:mangled4+0x10 "%s %f", arg1, arg2'
         ]
         self.assertEqual(result, expected)
 
@@ -273,12 +285,56 @@ class TestLoadFromFile(TestCase):
 
     @patch('tracerface.web_ui.trace_setup.yaml.safe_load', return_value={'dummy_built_in' : {}})
     @patch('tracerface.web_ui.trace_setup.Path.read_text')
-    def test_load_from_file_adds_built_in_if_binary_not_found(self, read, load):
+    @patch('tracerface.web_ui.trace_setup.Setup.get_offset_for_built_in', return_value=8)
+    def test_load_from_file_adds_built_in_if_binary_not_found(self, read, load, get_offset_for_built_in):
         setup = Setup()
         setup.load_from_file('dummy/path')
         self.assertIn('built-ins', setup._setup)
         self.assertIn('dummy_built_in', setup._setup['built-ins'])
 
+
+class TestGetOffsetForBuiltIn(TestCase):
+    @patch('tracerface.web_ui.trace_setup.check_output', side_effect=[b'0\n10', b'push %rbp\nmov %rsp,%rbp\n0x8'])
+    def test_get_offset_for_built_in_existing(self, check_output):
+        setup = Setup()
+        result = setup.get_offset_for_built_in('builtin_func')
+        expected = 8
+        self.assertEqual(result, expected)
+
+    @patch('tracerface.web_ui.trace_setup.check_output', side_effect=[b'0\n10', b'line1\nline2'])
+    def test_get_offset_for_built_in_no_match(self, check_output):
+        setup = Setup()
+        result = setup.get_offset_for_built_in('builtin_func')
+        expected = 0
+        self.assertEqual(result, expected)
+
+    def test_get_offset_for_built_in_non_existing(self):
+        setup = Setup()
+        with self.assertRaises(BuiltInNotExistsError):
+            setup.get_offset_for_built_in('no_such_built_in')
+
+
+class TestGetOffsetForFunction(TestCase):
+    @patch('tracerface.web_ui.trace_setup.check_output', return_value=b'push %rbp\nmov %rsp,%rbp\n<func1+0x1a>')
+    def test_get_offset_for_function_hexadecimal(self, check_output):
+        setup = Setup()
+        result = setup.get_offset_for_function('app', 'func1')
+        expected = 26
+        self.assertEqual(result, expected)
+
+    @patch('tracerface.web_ui.trace_setup.check_output', return_value=b'extra1\npush %rbp\nextra2\nmov %rsp,%rbp\nextra3\n<func2+0x8>')
+    def test_get_offset_for_function_extra_lines(self, check_output):
+        setup = Setup()
+        result = setup.get_offset_for_function('app', 'func2')
+        expected = 8
+        self.assertEqual(result, expected)
+
+    @patch('tracerface.web_ui.trace_setup.check_output', return_value=b'line1\nline2')
+    def test_get_offset_for_function_no_match(self, check_output):
+        setup = Setup()
+        result = setup.get_offset_for_function('app', 'func')
+        expected = 0
+        self.assertEqual(result, expected)
 
 if __name__ == '__main__':
     main()

--- a/tracerface/callbacks/dashboard_callbacks.py
+++ b/tracerface/callbacks/dashboard_callbacks.py
@@ -17,7 +17,8 @@ from tracerface.web_ui.trace_setup import (
     BinaryAlreadyAddedError,
     BinaryNotExistsError,
     ConfigFileError,
-    FunctionNotInBinaryError
+    FunctionNotInBinaryError,
+    BuiltInNotExistsError
 )
 
 
@@ -144,7 +145,12 @@ def update_apps_dropdown_options(app, setup):
             except BinaryNotExistsError:
                 msg = 'Binary not found at given path so it is assumed to be a built-in function'
                 alert = WarningAlert(msg)
-                setup.initialize_built_in(app_to_add)
+                try:
+                    setup.initialize_built_in(app_to_add)
+                except BuiltInNotExistsError:
+                    msg = 'Binary not found at given path, nor as built-in'
+                    alert = WarningAlert(msg)
+                    
         elif id == 'remove-app-button' and app_to_remove:
             setup.remove_app(app_to_remove)
         elif id == 'load-config-button' and config_path:

--- a/tracerface/parse_stack.py
+++ b/tracerface/parse_stack.py
@@ -11,7 +11,7 @@ from re import compile
 
 
 # Regex patterns to match in bcc trace output
-_FUNCTION_PATTERN = compile(r'^b\'(.+)\+.*\s\[(.+)\]')
+_FUNCTION_PATTERN = compile(r'([a-zA-Z0-9_]+)\+.*\s\[(.+)\]')
 _PARAMS_PATTERN = compile(r'^\d+\s+\d+\s+\S+\s+\S+\s+(.+)')
 _HEADER_PATTERN = compile(r'^PID\s+TID\s+COMM\s+FUNC')
 
@@ -77,7 +77,7 @@ def parse_stack(stack):
     traced = True
     while stack:
         call = stack.pop(0)
-        caller = _FUNCTION_PATTERN.match(call)
+        caller = _FUNCTION_PATTERN.search(call)
         if caller:
             caller_node = _create_node(caller)
             caller_hash = sha256(repr(caller_node).encode()).hexdigest()

--- a/tracerface/web_ui/trace_setup.py
+++ b/tracerface/web_ui/trace_setup.py
@@ -2,6 +2,7 @@ from enum import Enum
 from pathlib import Path
 from subprocess import CalledProcessError, check_output
 import yaml
+import re
 
 import cxxfilt
 
@@ -22,6 +23,11 @@ class ConfigFileError(Exception):
 
 
 class FunctionNotInBinaryError(Exception):
+    def __init__(self, message=''):
+        super().__init__(message)
+
+
+class BuiltInNotExistsError(Exception):
     def __init__(self, message=''):
         super().__init__(message)
 
@@ -50,17 +56,84 @@ class Setup:
             init_state[name] = {
                 'mangled': function,
                 'traced': False,
-                'parameters': {}
+                'parameters': {},
+                'offset': 0
             }
         self._setup[path] = init_state
 
+    # search offset after setting stack pointer for built-in function
+    def get_offset_for_built_in(self, func_name):
+        offset = 0
+        try:
+            # search address of function in symbol map
+            sym_address = check_output(
+                            ['sudo',
+                             'grep',
+                             '-A1',
+                             '-w',
+                             func_name,
+                             '/proc/kallsyms']
+                          ).decode().rstrip().split('\n')
+            if len(sym_address) == 2:
+                # address of given function
+                start_address = -1
+                start_address_match = re.search(r'^([a-f0-9]+)', sym_address[0])
+                if start_address_match:
+                    start_address = int(start_address_match.group(1), base=16)
+
+                # address of following symbol
+                stop_address = -1
+                stop_address_match = re.search(r'^([a-f0-9]+)', sym_address[1])
+                if stop_address_match:
+                    stop_address = int(stop_address_match.group(1), base=16)
+
+                if start_address >= 0 and stop_address >= 0:
+                    # get instructions of function
+                    objdump_out = check_output(
+                                ['sudo',
+                                    'objdump',
+                                    '--prefix-addresses',
+                                    '-d',
+                                    '--start-address=0x{:X}'.format(start_address),
+                                    '--stop-address=0x{:X}'.format(stop_address),
+                                    '/proc/kcore']
+                                ).decode().rstrip().split('\n')
+                    # search first instruction after function prologue
+                    first = False
+                    second = False
+                    for line in objdump_out:
+                        if first and second:
+                            func_offset = re.search(r'(0x[a-f0-9]+)', line)
+                            if func_offset:
+                                # needed offset is difference between function's base address and
+                                # address of first instruction after function prologue
+                                offset = int(func_offset.group(1), base=16) - start_address
+                                break
+
+                        # second instruction of function prologue
+                        if first and re.search(r'mov\s+%rsp,%rbp', line):
+                            second = True
+
+                        # first instruction of function prologue
+                        if not(first) and re.search(r'push\s+%rbp', line):
+                            first = True
+        except CalledProcessError:
+            raise BuiltInNotExistsError
+        return offset
+
+    # initialize built-in function to be traced
     def initialize_built_in(self, func_name):
         if 'built-ins' not in self._setup:
             self._setup['built-ins'] = {}
-        self._setup['built-ins'][func_name] = {
-            'traced': True,
-            'parameters': {}
-        }
+        try:
+            offset = self.get_offset_for_built_in(func_name)
+            self._setup['built-ins'][func_name] = {
+                'traced': True,
+                'parameters': {},
+                'offset': offset
+            }
+        except BuiltInNotExistsError:
+            raise
 
     # Remove application from getting traced
     def remove_app(self, app):
@@ -74,14 +147,47 @@ class Setup:
     def get_setup_of_app(self, app):
         return self._setup[app]
 
+    # search offset after setting stack pointer for user function
+    def get_offset_for_function(self, app_name, func_name):
+        offset = 0
+        # get instructions of function
+        try:
+            objdump_out = check_output(['objdump', "--disassemble="+func_name, "--prefix-addresses", app_name]).decode().rstrip().split('\n')
+        except CalledProcessError:
+            raise FunctionNotInBinaryError
+
+        first = False
+        second = False
+        for line in objdump_out:
+            if first and second:
+                # first instruction after function prologue with offset
+                func_offset = re.search(r'<'+func_name+r'\+(0x[a-f0-9]+)>', line)
+                if func_offset:
+                    offset = int(func_offset.group(1), base=16)
+                    break
+
+            # second instruction of function prologue
+            if first and re.search(r'mov\s+%rsp,%rbp', line):
+                second = True
+
+            # first instruction of function prologue
+            if not(first) and re.search(r'push\s+%rbp', line):
+                first = True
+        return offset
+
     # Sets up a function to be traced
     def setup_function_to_trace(self, app, function):
         try:
             self._setup[app][function]['traced'] = True
+            offset = self.get_offset_for_function(app, function)
+            self._setup[app][function]['offset'] = offset
+
         except KeyError:
             for func_name in self._setup[app]:
                 if self._setup[app][func_name]['mangled'] == function:
                     self._setup[app][func_name]['traced'] = True
+                    offset = self.get_offset_for_function(app, function)
+                    self._setup[app][func_name]['offset'] = offset
                     return
             raise FunctionNotInBinaryError(
                 'No function named {} was found in {}'.format(function, app)
@@ -120,9 +226,9 @@ class Setup:
             for function in self._setup[app]:
                 if self._setup[app][function]['traced']:
                     if app == 'built-ins':
-                        argument = function
+                        argument = '{}+0x{:X}'.format(function, self._setup[app][function]['offset'])
                     else:
-                        argument = '{}:{}'.format(app, self._setup[app][function]['mangled'])
+                        argument = '{}:{}+0x{:X}'.format(app, self._setup[app][function]['mangled'], self._setup[app][function]['offset'])
                     params = self._setup[app][function]['parameters']
                     if params:
                         argument = '{} "{}", {}'.format(
@@ -154,10 +260,13 @@ class Setup:
                     for index in config[app][function]:
                         self.add_parameter(app, function, index, config[app][function][index])
             except BinaryNotExistsError:
-                self.initialize_built_in(app)
-                for index in config[app]:
-                    self.add_parameter('built-ins', app, index, config[app][index])
-                err_message = 'Some binaries were not found so they were assumed to be built-in functions'
+                try:
+                    self.initialize_built_in(app)
+                    for index in config[app]:
+                        self.add_parameter('built-ins', app, index, config[app][index])
+                    err_message = 'Some binaries were not found so they were assumed to be built-in functions'
+                except BuiltInNotExistsError:
+                    err_message = 'Some binaries were not found, and neither as built-in functions'
             except TypeError:
                 raise ConfigFileError('File format is incorrect')
         return err_message


### PR DESCRIPTION
New functionality finds byte-offset of first instruction after the prologue in functions set to be traced, and uses this in the bcc trace call arguments. This way, the call graph will be correct as the base stack pointer is already updated.

- Added functions get_offset_for_built_in and get_offset_for_function.
- Integrated new functions into trace setup procedure.
- Added new kind of exception: BuiltInNotExistsError
- Updated unit tests and added new ones for the new functions.
- Updated expected results in integration test.
- Changed function pattern in stack parser to be more general.